### PR TITLE
Add a tarball of the large resource files to be pulled at build time.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+blobs filter=lfs diff=lfs merge=lfs -text

--- a/blobs/bin/cc-shapefiles/mac/10.11/0.1b/cc-shapefiles.tar.gz
+++ b/blobs/bin/cc-shapefiles/mac/10.11/0.1b/cc-shapefiles.tar.gz
@@ -1,0 +1,1 @@
+../../../linux/x86_64/0.1b/cc-shapefiles.tar.gz

--- a/blobs/bin/cc-shapefiles/mac/10.12/0.1b/cc-shapefiles.tar.gz
+++ b/blobs/bin/cc-shapefiles/mac/10.12/0.1b/cc-shapefiles.tar.gz
@@ -1,0 +1,1 @@
+../../10.11/0.1b/cc-shapefiles.tar.gz

--- a/blobs/bin/cc-shapefiles/mac/10.13/0.1b/cc-shapefiles.tar.gz
+++ b/blobs/bin/cc-shapefiles/mac/10.13/0.1b/cc-shapefiles.tar.gz
@@ -1,0 +1,1 @@
+../../10.11/0.1b/cc-shapefiles.tar.gz

--- a/country_revgeo/src/main/resources/README.md
+++ b/country_revgeo/src/main/resources/README.md
@@ -1,2 +1,7 @@
 cc-shapefiles
 =============
+
+NOTE(mateo): Greetings, from the future (the past to you, dear reader).
+
+In 2018, I began publishing this jar from our internal repo. This just brought in the
+Scala, the shapefile resources are still hosted from the foursquare/cc-shapefiles Github repo.

--- a/project/QuadtreeBuild.scala
+++ b/project/QuadtreeBuild.scala
@@ -13,7 +13,7 @@ object QuadtreeBuild extends Build {
   lazy val buildSettings = Seq(
     organization := "com.foursquare",
     name := "quadtree",
-    version      := "0.1a",
+    version      := "0.1b",
     scalaVersion := "2.12.2",
     crossScalaVersions := Seq("2.12.2", "2.11.11"),
     javacOptions ++= Seq("-source", "1.7", "-target", "1.7"),


### PR DESCRIPTION
This bumps the version but does not include a publish. The country_revgeo resources are 
checked into the repo as a tarball with the git-lfs attribute bit set.

We have moved the code into Fsq.io (https://github.com/foursquare/fsqio) and will be
publishing the jars anew from that repo.

The tarball hosted here will be bootstrapped  by Pants at build time (using `remote_sources` target)
by OSS consumers.