### PR TITLE
Consolidate on platform-agnostic namespace for blob archive.

### DIFF
--- a/blobs/bin/cc-shapefiles/mac/10.11/0.1b/cc-shapefiles.tar.gz
+++ b/blobs/bin/cc-shapefiles/mac/10.11/0.1b/cc-shapefiles.tar.gz
@@ -1,1 +1,0 @@
-../../../linux/x86_64/0.1b/cc-shapefiles.tar.gz

--- a/blobs/bin/cc-shapefiles/mac/10.12/0.1b/cc-shapefiles.tar.gz
+++ b/blobs/bin/cc-shapefiles/mac/10.12/0.1b/cc-shapefiles.tar.gz
@@ -1,1 +1,0 @@
-../../10.11/0.1b/cc-shapefiles.tar.gz

--- a/blobs/bin/cc-shapefiles/mac/10.13/0.1b/cc-shapefiles.tar.gz
+++ b/blobs/bin/cc-shapefiles/mac/10.13/0.1b/cc-shapefiles.tar.gz
@@ -1,1 +1,0 @@
-../../10.11/0.1b/cc-shapefiles.tar.gz


### PR DESCRIPTION
We modified the Pants task that consumes this blob to understand platform_dependent
tools as well as the reverse. This allows us to host source packages in a universal namespace
without the unnecessary duplication.

Sorry to pad the checkout size though...